### PR TITLE
Add repo and project links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Parkhaus Simulation
 
+[GitHub Repo](https://github.com/kataranum/parkhaus-simulation.git)
+[Projekt Canbanboard](https://github.com/users/kataranum/projects/2)
+
 Gruppenprojekt "Parkhaus-Simulation" für Vorlesung Programmieren I von Christian
 Braunagel.
 


### PR DESCRIPTION
Damit Herr Braunagel Links auf das Repo und Board hat, weil die Abgabe auf Moodle als ZIP Datei erfolgt.